### PR TITLE
Add legacy stream protocol

### DIFF
--- a/src/StreamResource/ReadProtocol.php
+++ b/src/StreamResource/ReadProtocol.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Storj\Uplink\StreamResource;
+
+use Storj\Uplink\CursoredDownload;
+
+/**
+ * Implementation of https://www.php.net/manual/en/class.streamwrapper.php
+ */
+class ReadProtocol
+{
+    protected const PROTOCOL = 'storj';
+
+    /**
+     * This is set by PHP when opening the stream.
+     * It can be read with stream_context_get_options().
+     *
+     * @var resource
+     */
+    protected $context;
+
+    protected CursoredDownload $download;
+
+    /**
+     * Convert a Storj download into a resource for usage with fread() etc
+     *
+     * @return resource
+     */
+    public static function createReadResource(CursoredDownload $download)
+    {
+        try {
+            stream_wrapper_register(self::PROTOCOL, self::class);
+
+            $context = stream_context_create([
+                self::PROTOCOL => [
+                    'download' => $download,
+                ]
+            ]);
+
+            return fopen(self::PROTOCOL . '://', 'r', false, $context);
+        } finally {
+            stream_wrapper_unregister(self::PROTOCOL);
+        }
+    }
+
+    protected function setDownloadFromContext(): void
+    {
+        $context = stream_context_get_options($this->context);
+
+        $this->download = $context[self::PROTOCOL]['download'];
+    }
+
+    /*
+     * Below are callbacks for PHP.
+     * You should not call these methods directly.
+     */
+
+    public function stream_open(string $path, string $mode, int $options, ?string &$opened_path): bool
+    {
+        $this->setDownloadFromContext();
+        return true;
+    }
+
+    public function stream_read(int $count): string
+    {
+        return $this->download->read($count);
+    }
+
+    public function stream_eof(): bool
+    {
+        return $this->download->isDone();
+    }
+
+    /**
+     * necessary for @see stream_copy_to_stream()
+     */
+    public function stream_stat(): array
+    {
+        $systemMetaData = $this->download->info()->getSystemMetadata();
+
+        return [
+            'size' => $systemMetaData->getContentLength(),
+            'mtime' => $systemMetaData->getCreated()->format('U'),
+        ];
+    }
+}

--- a/src/StreamResource/WriteProtocol.php
+++ b/src/StreamResource/WriteProtocol.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Storj\Uplink\StreamResource;
+
+use Storj\Uplink\Upload;
+
+/**
+ * Implementation of https://www.php.net/manual/en/class.streamwrapper.php
+ */
+class WriteProtocol
+{
+    protected const PROTOCOL = 'storj';
+
+    /**
+     * This is set by PHP when opening the stream.
+     * It can be read with stream_context_get_options().
+     *
+     * @var resource
+     */
+    protected $context;
+
+    protected Upload $upload;
+
+    /**
+     * Convert a Storj upload into resource for usage with fwrite() and fclose() etc
+     *
+     * @return resource
+     */
+    public static function createWriteResource(Upload $upload)
+    {
+        try {
+            stream_wrapper_register(self::PROTOCOL, self::class);
+
+            $context = stream_context_create([
+                self::PROTOCOL => [
+                    'upload' => $upload,
+                ]
+            ]);
+
+            return fopen(self::PROTOCOL . '://', 'w', false, $context);
+        } finally {
+            stream_wrapper_unregister(self::PROTOCOL);
+        }
+    }
+
+    protected function setUploadFromContext(): void
+    {
+        $context = stream_context_get_options($this->context);
+
+        $this->upload = $context[self::PROTOCOL]['upload'];
+    }
+
+    /*
+     * Below are callbacks for PHP.
+     * You should not call these methods directly.
+     */
+
+    public function stream_open(string $path, string $mode, int $options, ?string &$opened_path): bool
+    {
+        $this->setUploadFromContext();
+        return true;
+    }
+
+    public function stream_write(string $data): int
+    {
+        $this->upload->write($data);
+
+        return strlen($data);
+    }
+
+    public function stream_close(): void
+    {
+        $this->upload->commit();
+    }
+}

--- a/test/StreamResourceTest.php
+++ b/test/StreamResourceTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Storj\Uplink\Test\LegacyStream;
+
+use PHPUnit\Framework\TestCase;
+use Storj\Uplink\StreamResource\ReadProtocol;
+use Storj\Uplink\StreamResource\WriteProtocol;
+use Storj\Uplink\Test\Util;
+
+class StreamResourceTest extends TestCase
+{
+    public function testUploadAndDownloadViaLegacyStream()
+    {
+        $project = Util::emptyAccess()->openProject();
+        $project->createBucket('phpunit');
+
+        $upload = $project->uploadObject('phpunit', self::class);
+        $writeStream = WriteProtocol::createWriteResource($upload);
+
+        $writeContent = bin2hex(random_bytes(32));
+        fwrite($writeStream, $writeContent);
+        fclose($writeStream);
+
+        $download = $project->downloadObject('phpunit', self::class);
+        $readStream = ReadProtocol::createReadResource($download->cursored());
+        $readContent = fread($readStream, 1024);
+
+        self::assertEquals($readContent, $writeContent);
+    }
+
+    public function testStreamCopy()
+    {
+        $project = Util::emptyAccess()->openProject();
+        $project->createBucket('phpunit');
+
+        $content = bin2hex(random_bytes(32));
+        $contentStream = fopen('php://memory', 'w+');
+        fwrite($contentStream, $content);
+        rewind($contentStream); // is it necessary?
+
+        $upload = $project->uploadObject('phpunit', self::class);
+        $writeStream = WriteProtocol::createWriteResource($upload);
+        stream_copy_to_stream($contentStream, $writeStream);
+        fclose($writeStream); // is it necessary?
+
+        $download = $project->downloadObject('phpunit', self::class);
+        $readStream = ReadProtocol::createReadResource($download->cursored());
+        $resultStream = fopen('php://memory', 'w+');
+        stream_copy_to_stream($readStream, $resultStream);
+        rewind($resultStream);
+        $result = stream_get_contents($resultStream);
+
+        self::assertEquals($content, $result);
+    }
+}


### PR DESCRIPTION
Merge #2 first then change target branch to master

Remove friction when working with libraries/frameworks which use these streams.

You need this to implement a nextcloud backend https://github.com/nextcloud/server/blob/v19.0.1/lib/public/Files/Storage/IStorage.php#L272

This is not a full protocol which can handle all the fopen() flags, just 2 static methods to make a write or read stream.

It might still be necessary to implement a full read/write protocol. the S3 nextcloud backend does this by maintaining a local copy of the entire remote object and flushing it at the end. We'll see.