### PR TITLE
Uplink c 1.2.2

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ pipeline {
         stage('Go build') {
             agent {
                 docker {
-                    image docker.build("storj-ci", "--pull https://github.com/storj/ci.git").id
+                    image docker.build("storj-ci", "--pull https://github.com/storj/ci.git#main").id
                     args '--user root:root --cap-add SYS_PTRACE -v "/tmp/gomod":/go/pkg/mod '
                 }
             }
@@ -36,7 +36,7 @@ pipeline {
         stage('PHPStan') {
             agent {
                 docker {
-                    image 'phpstan/phpstan:0.12.33'
+                    image 'phpstan/phpstan:0.12.65'
                     args '--mount type=volume,source=phpstan-cache,destination=/tmp/phpstan ' +
                         '-u root:root ' +
                         "--entrypoint='' "

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,7 +1,7 @@
 Automated testing
 -----
 
-Install dependencies using `composer install`, then set up an environment;
+Install dependencies using `composer install`, then set up an environment with your tardigrade credentials:
 
 ```
 #!/bin/bash

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ For better response times of your web app, you should serialize your credentials
 ```php
 require 'vendor/autoload.php';
 $access = \Storj\Uplink\Uplink::create()->requestAccessWithPassphrase(
-    'europe-west-1.tardigrade.io:7777',
+    '12L9ZFwhzVpuEKMUNUqkaTLGzwY9G24tbiigLiXpmZWKwmcNDDs@europe-west-1.tardigrade.io:7777',
     'mybase58apikey',
     'mypassphrase'
 );

--- a/build.sh
+++ b/build.sh
@@ -1,12 +1,14 @@
 #!/bin/bash
 set -e
-mkdir -p tmp-c
-git clone --branch v1.0.5 https://github.com/storj/uplink-c.git tmp-c
+rm -rf tmp-c
+mkdir tmp-c
+git clone --branch v1.2.2 https://github.com/storj/uplink-c.git tmp-c
 cd tmp-c
-## prefer Go release 2.15 because it preserves parameter names in the header file
+## prefer Go release >=1.15 (aug-2020) because it preserves parameter names in the header file
 make build
 cd ..
-cat tmp-c/.build/uplink_definitions.h tmp-c/.build/uplink.h > build/uplink-php.h
+mkdir -p build
+cat tmp-c/.build/uplink/uplink_definitions.h tmp-c/.build/uplink/uplink.h > build/uplink-php.h
 cat tmp-c/.build/libuplink.so > build/libuplink.so
 ## remove stuff PHP can't handle
 sed -i 's/typedef __SIZE_TYPE__ GoUintptr;//g' build/uplink-php.h

--- a/build/uplink-php.h
+++ b/build/uplink-php.h
@@ -8,95 +8,107 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-typedef struct Handle {
-    size_t _handle;
-} Handle;
+#include "uplink_compat.h"
 
-typedef struct Access {
-    size_t _handle;
-} Access;
-typedef struct Project {
-    size_t _handle;
-} Project;
-typedef struct Download {
-    size_t _handle;
-} Download;
-typedef struct Upload {
-    size_t _handle;
-} Upload;
+typedef const char uplink_const_char;
 
-typedef struct Config {
-    char *user_agent;
+typedef struct UplinkHandle {
+    size_t _handle;
+} UplinkHandle;
+
+typedef struct UplinkAccess {
+    size_t _handle;
+} UplinkAccess;
+
+typedef struct UplinkProject {
+    size_t _handle;
+} UplinkProject;
+
+typedef struct UplinkDownload {
+    size_t _handle;
+} UplinkDownload;
+
+typedef struct UplinkUpload {
+    size_t _handle;
+} UplinkUpload;
+
+typedef struct UplinkEncryptionKey {
+    size_t _handle;
+} UplinkEncryptionKey;
+
+typedef struct UplinkConfig {
+    const char *user_agent;
 
     int32_t dial_timeout_milliseconds;
 
     // temp_directory specifies where to save data during downloads to use less memory.
-    char *temp_directory;
-} Config;
+    const char *temp_directory;
+} UplinkConfig;
 
-typedef struct Bucket {
+typedef struct UplinkBucket {
     char *name;
     int64_t created;
-} Bucket;
+} UplinkBucket;
 
-typedef struct SystemMetadata {
+typedef struct UplinkSystemMetadata {
     int64_t created;
     int64_t expires;
     int64_t content_length;
-} SystemMetadata;
+} UplinkSystemMetadata;
 
-typedef struct CustomMetadataEntry {
+typedef struct UplinkCustomMetadataEntry {
     char *key;
     size_t key_length;
 
     char *value;
     size_t value_length;
-} CustomMetadataEntry;
+} UplinkCustomMetadataEntry;
 
-typedef struct CustomMetadata {
-    CustomMetadataEntry *entries;
+typedef struct UplinkCustomMetadata {
+    UplinkCustomMetadataEntry *entries;
     size_t count;
-} CustomMetadata;
+} UplinkCustomMetadata;
 
-typedef struct Object {
+typedef struct UplinkObject {
     char *key;
     bool is_prefix;
-    SystemMetadata system;
-    CustomMetadata custom;
-} Object;
+    UplinkSystemMetadata system;
+    UplinkCustomMetadata custom;
+} UplinkObject;
 
-typedef struct UploadOptions {
+typedef struct UplinkUploadOptions {
     // When expires is 0 or negative, it means no expiration.
     int64_t expires;
-} UploadOptions;
+} UplinkUploadOptions;
 
-typedef struct DownloadOptions {
+typedef struct UplinkDownloadOptions {
     int64_t offset;
     // When length is negative, it will read until the end of the blob.
     int64_t length;
-} DownloadOptions;
+} UplinkDownloadOptions;
 
-typedef struct ListObjectsOptions {
-    char *prefix;
-    char *cursor;
+typedef struct UplinkListObjectsOptions {
+    const char *prefix;
+    const char *cursor;
     bool recursive;
 
     bool system;
     bool custom;
-} ListObjectsOptions;
+} UplinkListObjectsOptions;
 
-typedef struct ListBucketsOptions {
-    char *cursor;
-} ListBucketsOptions;
+typedef struct UplinkListBucketsOptions {
+    const char *cursor;
+} UplinkListBucketsOptions;
 
-typedef struct ObjectIterator {
+typedef struct UplinkObjectIterator {
     size_t _handle;
-} ObjectIterator;
-typedef struct BucketIterator {
-    size_t _handle;
-} BucketIterator;
+} UplinkObjectIterator;
 
-typedef struct Permission {
+typedef struct UplinkBucketIterator {
+    size_t _handle;
+} UplinkBucketIterator;
+
+typedef struct UplinkPermission {
     bool allow_download;
     bool allow_upload;
     bool allow_list;
@@ -108,78 +120,83 @@ typedef struct Permission {
     // unix time in seconds when the permission becomes invalid.
     // disabled when 0.
     int64_t not_after;
-} Permission;
+} UplinkPermission;
 
-typedef struct SharePrefix {
-    char *bucket;
+typedef struct UplinkSharePrefix {
+    const char *bucket;
     // prefix is the prefix of the shared object keys.
-    char *prefix;
-} SharePrefix;
+    const char *prefix;
+} UplinkSharePrefix;
 
-typedef struct Error {
+typedef struct UplinkError {
     int32_t code;
     char *message;
-} Error;
+} UplinkError;
 
-#define ERROR_INTERNAL 0x02
-#define ERROR_CANCELED 0x03
-#define ERROR_INVALID_HANDLE 0x04
-#define ERROR_TOO_MANY_REQUESTS 0x05
-#define ERROR_BANDWIDTH_LIMIT_EXCEEDED 0x06
+#define UPLINK_ERROR_INTERNAL 0x02
+#define UPLINK_ERROR_CANCELED 0x03
+#define UPLINK_ERROR_INVALID_HANDLE 0x04
+#define UPLINK_ERROR_TOO_MANY_REQUESTS 0x05
+#define UPLINK_ERROR_BANDWIDTH_LIMIT_EXCEEDED 0x06
 
-#define ERROR_BUCKET_NAME_INVALID 0x10
-#define ERROR_BUCKET_ALREADY_EXISTS 0x11
-#define ERROR_BUCKET_NOT_EMPTY 0x12
-#define ERROR_BUCKET_NOT_FOUND 0x13
+#define UPLINK_ERROR_BUCKET_NAME_INVALID 0x10
+#define UPLINK_ERROR_BUCKET_ALREADY_EXISTS 0x11
+#define UPLINK_ERROR_BUCKET_NOT_EMPTY 0x12
+#define UPLINK_ERROR_BUCKET_NOT_FOUND 0x13
 
-#define ERROR_OBJECT_KEY_INVALID 0x20
-#define ERROR_OBJECT_NOT_FOUND 0x21
-#define ERROR_UPLOAD_DONE 0x22
+#define UPLINK_ERROR_OBJECT_KEY_INVALID 0x20
+#define UPLINK_ERROR_OBJECT_NOT_FOUND 0x21
+#define UPLINK_ERROR_UPLOAD_DONE 0x22
 
-typedef struct AccessResult {
-    Access *access;
-    Error *error;
-} AccessResult;
+typedef struct UplinkAccessResult {
+    UplinkAccess *access;
+    UplinkError *error;
+} UplinkAccessResult;
 
-typedef struct ProjectResult {
-    Project *project;
-    Error *error;
-} ProjectResult;
+typedef struct UplinkProjectResult {
+    UplinkProject *project;
+    UplinkError *error;
+} UplinkProjectResult;
 
-typedef struct BucketResult {
-    Bucket *bucket;
-    Error *error;
-} BucketResult;
+typedef struct UplinkBucketResult {
+    UplinkBucket *bucket;
+    UplinkError *error;
+} UplinkBucketResult;
 
-typedef struct ObjectResult {
-    Object *object;
-    Error *error;
-} ObjectResult;
+typedef struct UplinkObjectResult {
+    UplinkObject *object;
+    UplinkError *error;
+} UplinkObjectResult;
 
-typedef struct UploadResult {
-    Upload *upload;
-    Error *error;
-} UploadResult;
+typedef struct UplinkUploadResult {
+    UplinkUpload *upload;
+    UplinkError *error;
+} UplinkUploadResult;
 
-typedef struct DownloadResult {
-    Download *download;
-    Error *error;
-} DownloadResult;
+typedef struct UplinkDownloadResult {
+    UplinkDownload *download;
+    UplinkError *error;
+} UplinkDownloadResult;
 
-typedef struct WriteResult {
+typedef struct UplinkWriteResult {
     size_t bytes_written;
-    Error *error;
-} WriteResult;
+    UplinkError *error;
+} UplinkWriteResult;
 
-typedef struct ReadResult {
+typedef struct UplinkReadResult {
     size_t bytes_read;
-    Error *error;
-} ReadResult;
+    UplinkError *error;
+} UplinkReadResult;
 
-typedef struct StringResult {
+typedef struct UplinkStringResult {
     char *string;
-    Error *error;
-} StringResult;
+    UplinkError *error;
+} UplinkStringResult;
+
+typedef struct UplinkEncryptionKeyResult {
+    UplinkEncryptionKey *encryption_key;
+    UplinkError *error;
+} UplinkEncryptionKeyResult;
 /* Code generated by cmd/cgo; DO NOT EDIT. */
 
 /* package storj.io/uplink-c */
@@ -226,12 +243,18 @@ typedef struct { const char *p; ptrdiff_t n; } _GoString_;
 
 #line 1 "cgo-generated-wrapper"
 
+#line 6 "encryption.go"
+ #include "uplink_definitions.h"
+
+#line 1 "cgo-generated-wrapper"
+
 #line 6 "error.go"
  #include "uplink_definitions.h"
 
 #line 1 "cgo-generated-wrapper"
 
 #line 6 "main.go"
+
  #include "uplink_definitions.h"
 
 #line 1 "cgo-generated-wrapper"
@@ -305,160 +328,185 @@ typedef struct { void *data; GoInt len; GoInt cap; } GoSlice;
 
 
 
-// parse_access parses serialized access grant string.
-extern AccessResult parse_access(char* accessString);
+// uplink_parse_access parses serialized access grant string.
+extern UplinkAccessResult uplink_parse_access(uplink_const_char* accessString);
 
-// request_access_with_passphrase requests satellite for a new access grant using a passhprase.
-extern AccessResult request_access_with_passphrase(char* satellite_address, char* api_key, char* passphrase);
+// uplink_request_access_with_passphrase requests satellite for a new access grant using a passhprase.
+extern UplinkAccessResult uplink_request_access_with_passphrase(uplink_const_char* satellite_address, uplink_const_char* api_key, uplink_const_char* passphrase);
 
-// access_serialize serializes access grant into a string.
-extern StringResult access_serialize(Access* access);
+// uplink_access_satellite_address returns the satellite node URL for this access grant.
+extern UplinkStringResult uplink_access_satellite_address(UplinkAccess* access);
 
-// access_share creates new access grant with specific permission. Permission will be applied to prefixes when defined.
-extern AccessResult access_share(Access* access, Permission permission, SharePrefix* prefixes, GoInt prefixes_count);
+// uplink_access_serialize serializes access grant into a string.
+extern UplinkStringResult uplink_access_serialize(UplinkAccess* access);
 
-// free_string_result frees the resources associated with string result.
-extern void free_string_result(StringResult result);
+// uplink_access_share creates new access grant with specific permission. Permission will be applied to prefixes when defined.
+extern UplinkAccessResult uplink_access_share(UplinkAccess* access, UplinkPermission permission, UplinkSharePrefix* prefixes, GoInt prefixes_count);
 
-// free_access_result frees the resources associated with access grant.
-extern void free_access_result(AccessResult result);
+// uplink_access_override_encryption_key overrides the root encryption key for the prefix in
+// bucket with encryptionKey.
+//
+// This function is useful for overriding the encryption key in user-specific
+// access grants when implementing multitenancy in a single app bucket.
+extern UplinkError* uplink_access_override_encryption_key(UplinkAccess* access, uplink_const_char* bucket, uplink_const_char* prefix, UplinkEncryptionKey* encryptionKey);
 
-// stat_bucket returns information about a bucket.
-extern BucketResult stat_bucket(Project* project, char* bucket_name);
+// uplink_free_string_result frees the resources associated with string result.
+extern void uplink_free_string_result(UplinkStringResult result);
 
-// create_bucket creates a new bucket.
+// uplink_free_access_result frees the resources associated with access grant.
+extern void uplink_free_access_result(UplinkAccessResult result);
+
+// uplink_stat_bucket returns information about a bucket.
+extern UplinkBucketResult uplink_stat_bucket(UplinkProject* project, uplink_const_char* bucket_name);
+
+// uplink_create_bucket creates a new bucket.
 //
 // When bucket already exists it returns a valid Bucket and ErrBucketExists.
-extern BucketResult create_bucket(Project* project, char* bucket_name);
+extern UplinkBucketResult uplink_create_bucket(UplinkProject* project, uplink_const_char* bucket_name);
 
-// ensure_bucket creates a new bucket and ignores the error when it already exists.
+// uplink_ensure_bucket creates a new bucket and ignores the error when it already exists.
 //
 // When bucket already exists it returns a valid Bucket and ErrBucketExists.
-extern BucketResult ensure_bucket(Project* project, char* bucket_name);
+extern UplinkBucketResult uplink_ensure_bucket(UplinkProject* project, uplink_const_char* bucket_name);
 
-// delete_bucket deletes a bucket.
+// uplink_delete_bucket deletes a bucket.
 //
 // When bucket is not empty it returns ErrBucketNotEmpty.
-extern BucketResult delete_bucket(Project* project, char* bucket_name);
+extern UplinkBucketResult uplink_delete_bucket(UplinkProject* project, uplink_const_char* bucket_name);
 
-// free_bucket_result frees memory associated with the BucketResult.
-extern void free_bucket_result(BucketResult result);
+// uplink_delete_bucket_with_objects deletes a bucket and all objects within that bucket.
+//
+// When there are concurrent writes to the bucket it returns ErrBucketNotEmpty.
+extern UplinkBucketResult uplink_delete_bucket_with_objects(UplinkProject* project, uplink_const_char* bucket_name);
 
-// free_bucket frees memory associated with the bucket.
-extern void free_bucket(Bucket* bucket);
+// uplink_free_bucket_result frees memory associated with the BucketResult.
+extern void uplink_free_bucket_result(UplinkBucketResult result);
 
-// list_buckets lists buckets
-extern BucketIterator* list_buckets(Project* project, ListBucketsOptions* options);
+// uplink_free_bucket frees memory associated with the bucket.
+extern void uplink_free_bucket(UplinkBucket* bucket);
 
-// bucket_iterator_next prepares next Bucket for reading.
+// uplink_list_buckets lists buckets.
+extern UplinkBucketIterator* uplink_list_buckets(UplinkProject* project, UplinkListBucketsOptions* options);
+
+// uplink_bucket_iterator_next prepares next Bucket for reading.
 //
 // It returns false if the end of the iteration is reached and there are no more buckets, or if there is an error.
-extern _Bool bucket_iterator_next(BucketIterator* iterator);
+extern _Bool uplink_bucket_iterator_next(UplinkBucketIterator* iterator);
 
-// bucket_iterator_err returns error, if one happened during iteration.
-extern Error* bucket_iterator_err(BucketIterator* iterator);
+// uplink_bucket_iterator_err returns error, if one happened during iteration.
+extern UplinkError* uplink_bucket_iterator_err(UplinkBucketIterator* iterator);
 
-// bucket_iterator_item returns the current bucket in the iterator.
-extern Bucket* bucket_iterator_item(BucketIterator* iterator);
+// uplink_bucket_iterator_item returns the current bucket in the iterator.
+extern UplinkBucket* uplink_bucket_iterator_item(UplinkBucketIterator* iterator);
 
-// free_bucket_iterator frees memory associated with the BucketIterator.
-extern void free_bucket_iterator(BucketIterator* iterator);
+// uplink_free_bucket_iterator frees memory associated with the BucketIterator.
+extern void uplink_free_bucket_iterator(UplinkBucketIterator* iterator);
 
-// config_request_access_with_passphrase requests satellite for a new access grant using a passhprase.
-extern AccessResult config_request_access_with_passphrase(Config config, char* satellite_address, char* api_key, char* passphrase);
+// uplink_config_request_access_with_passphrase requests satellite for a new access grant using a passhprase.
+extern UplinkAccessResult uplink_config_request_access_with_passphrase(UplinkConfig config, uplink_const_char* satellite_address, uplink_const_char* api_key, uplink_const_char* passphrase);
 
-// config_open_project opens project using access grant.
-extern ProjectResult config_open_project(Config config, Access* access);
+// uplink_config_open_project opens project using access grant.
+extern UplinkProjectResult uplink_config_open_project(UplinkConfig config, UplinkAccess* access);
 
-// download_object starts  download to the specified key.
-extern DownloadResult download_object(Project* project, char* bucket_name, char* object_key, DownloadOptions* options);
+// uplink_download_object starts  download to the specified key.
+extern UplinkDownloadResult uplink_download_object(UplinkProject* project, uplink_const_char* bucket_name, uplink_const_char* object_key, UplinkDownloadOptions* options);
 
-// download_read downloads from object's data stream into bytes up to length amount.
+// uplink_download_read downloads from object's data stream into bytes up to length amount.
 // It returns the number of bytes read (0 <= bytes_read <= length) and
 // any error encountered that caused the read to stop early.
-extern ReadResult download_read(Download* download, void* bytes, size_t length);
+extern UplinkReadResult uplink_download_read(UplinkDownload* download, void* bytes, size_t length);
 
-// download_info returns information about the downloaded object.
-extern ObjectResult download_info(Download* download);
+// uplink_download_info returns information about the downloaded object.
+extern UplinkObjectResult uplink_download_info(UplinkDownload* download);
 
-// free_read_result frees any resources associated with read result.
-extern void free_read_result(ReadResult result);
+// uplink_free_read_result frees any resources associated with read result.
+extern void uplink_free_read_result(UplinkReadResult result);
 
-// close_download closes the download.
-extern Error* close_download(Download* download);
+// uplink_close_download closes the download.
+extern UplinkError* uplink_close_download(UplinkDownload* download);
 
-// free_download_result frees any associated resources.
-extern void free_download_result(DownloadResult result);
+// uplink_free_download_result frees any associated resources.
+extern void uplink_free_download_result(UplinkDownloadResult result);
 
-// free_error frees error data.
-extern void free_error(Error* err);
+// uplink_derive_encryption_key derives a salted encryption key for passphrase using the
+// salt.
+//
+// This function is useful for deriving a salted encryption key for users when
+// implementing multitenancy in a single app bucket.
+extern UplinkEncryptionKeyResult uplink_derive_encryption_key(uplink_const_char* passphrase, void* salt, size_t length);
 
-// internal_UniverseIsEmpty returns true if nothing is stored in the global map.
-extern GoUint8 internal_UniverseIsEmpty();
+// uplink_free_encryption_key_result frees the resources associated with encryption key.
+extern void uplink_free_encryption_key_result(UplinkEncryptionKeyResult result);
 
-// stat_object returns information about an object at the specific key.
-extern ObjectResult stat_object(Project* project, char* bucket_name, char* object_key);
+// uplink_free_error frees error data.
+extern void uplink_free_error(UplinkError* err);
 
-// delete_object deletes an object.
-extern ObjectResult delete_object(Project* project, char* bucket_name, char* object_key);
+// uplink_internal_UniverseIsEmpty returns true if nothing is stored in the global map.
+extern GoUint8 uplink_internal_UniverseIsEmpty();
 
-// free_object_result frees memory associated with the ObjectResult.
-extern void free_object_result(ObjectResult obj);
+// uplink_stat_object returns information about an object at the specific key.
+extern UplinkObjectResult uplink_stat_object(UplinkProject* project, uplink_const_char* bucket_name, uplink_const_char* object_key);
 
-// free_object frees memory associated with the Object.
-extern void free_object(Object* obj);
+// uplink_delete_object deletes an object.
+extern UplinkObjectResult uplink_delete_object(UplinkProject* project, uplink_const_char* bucket_name, uplink_const_char* object_key);
 
-// list_objects lists objects
-extern ObjectIterator* list_objects(Project* project, char* bucket_name, ListObjectsOptions* options);
+// uplink_free_object_result frees memory associated with the ObjectResult.
+extern void uplink_free_object_result(UplinkObjectResult obj);
 
-// object_iterator_next prepares next Object for reading.
+// uplink_free_object frees memory associated with the Object.
+extern void uplink_free_object(UplinkObject* obj);
+
+// uplink_list_objects lists objects.
+extern UplinkObjectIterator* uplink_list_objects(UplinkProject* project, uplink_const_char* bucket_name, UplinkListObjectsOptions* options);
+
+// uplink_object_iterator_next prepares next Object for reading.
 //
 // It returns false if the end of the iteration is reached and there are no more objects, or if there is an error.
-extern _Bool object_iterator_next(ObjectIterator* iterator);
+extern _Bool uplink_object_iterator_next(UplinkObjectIterator* iterator);
 
-// object_iterator_err returns error, if one happened during iteration.
-extern Error* object_iterator_err(ObjectIterator* iterator);
+// uplink_object_iterator_err returns error, if one happened during iteration.
+extern UplinkError* uplink_object_iterator_err(UplinkObjectIterator* iterator);
 
-// object_iterator_item returns the current object in the iterator.
-extern Object* object_iterator_item(ObjectIterator* iterator);
+// uplink_object_iterator_item returns the current object in the iterator.
+extern UplinkObject* uplink_object_iterator_item(UplinkObjectIterator* iterator);
 
-// free_object_iterator frees memory associated with the ObjectIterator.
-extern void free_object_iterator(ObjectIterator* iterator);
+// uplink_free_object_iterator frees memory associated with the ObjectIterator.
+extern void uplink_free_object_iterator(UplinkObjectIterator* iterator);
 
-// open_project opens project using access grant.
-extern ProjectResult open_project(Access* access);
+// uplink_open_project opens project using access grant.
+extern UplinkProjectResult uplink_open_project(UplinkAccess* access);
 
-// close_project closes the project.
-extern Error* close_project(Project* project);
+// uplink_close_project closes the project.
+extern UplinkError* uplink_close_project(UplinkProject* project);
 
-// free_project_result frees any associated resources.
-extern void free_project_result(ProjectResult result);
+// uplink_free_project_result frees any associated resources.
+extern void uplink_free_project_result(UplinkProjectResult result);
 
-// upload_object starts an upload to the specified key.
-extern UploadResult upload_object(Project* project, char* bucket_name, char* object_key, UploadOptions* options);
+// uplink_upload_object starts an upload to the specified key.
+extern UplinkUploadResult uplink_upload_object(UplinkProject* project, uplink_const_char* bucket_name, uplink_const_char* object_key, UplinkUploadOptions* options);
 
-// upload_write uploads len(p) bytes from p to the object's data stream.
+// uplink_upload_write uploads len(p) bytes from p to the object's data stream.
 // It returns the number of bytes written from p (0 <= n <= len(p)) and
 // any error encountered that caused the write to stop early.
-extern WriteResult upload_write(Upload* upload, void* bytes, size_t length);
+extern UplinkWriteResult uplink_upload_write(UplinkUpload* upload, void* bytes, size_t length);
 
-// upload_commit commits the uploaded data.
-extern Error* upload_commit(Upload* upload);
+// uplink_upload_commit commits the uploaded data.
+extern UplinkError* uplink_upload_commit(UplinkUpload* upload);
 
-// upload_abort aborts an upload.
-extern Error* upload_abort(Upload* upload);
+// uplink_upload_abort aborts an upload.
+extern UplinkError* uplink_upload_abort(UplinkUpload* upload);
 
-// upload_info returns the last information about the uploaded object.
-extern ObjectResult upload_info(Upload* upload);
+// uplink_upload_info returns the last information about the uploaded object.
+extern UplinkObjectResult uplink_upload_info(UplinkUpload* upload);
 
-// upload_set_custom_metadata returns the last information about the uploaded object.
-extern Error* upload_set_custom_metadata(Upload* upload, CustomMetadata custom);
+// uplink_upload_set_custom_metadata returns the last information about the uploaded object.
+extern UplinkError* uplink_upload_set_custom_metadata(UplinkUpload* upload, UplinkCustomMetadata custom);
 
-// free_write_result frees any resources associated with write result.
-extern void free_write_result(WriteResult result);
+// uplink_free_write_result frees any resources associated with write result.
+extern void uplink_free_write_result(UplinkWriteResult result);
 
-// free_upload_result closes the upload and frees any associated resources.
-extern void free_upload_result(UploadResult result);
+// uplink_free_upload_result closes the upload and frees any associated resources.
+extern void uplink_free_upload_result(UplinkUploadResult result);
 
 
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -6,19 +6,7 @@ parameters:
     ignoreErrors:
         - '/Call to an undefined method FFI::.*/'
         - '/Access to an undefined property FFI\\CData::.*/'
-        - '/Cannot access offset int on FFI\\CData./'
-        - '/Cannot access offset 0 on FFI\\CData./'
         -
-            message: '/Result of static method FFI::free\(\) \(void\) is used./'
-            paths:
-                - src/Internal/Util.php
-                - src/Upload.php
-        -
-            message: '/Anonymous function with return type void returns void but should not return anything./'
-            paths:
-                - src/Internal/Util.php
-                - src/Upload.php
-        -
-            message: '/Binary operation "-" between string and string results in an error./'
+            message: '/Binary operation "-" between string&numeric and string results in an error./'
             paths:
                 - test/ListObjectsTest.php

--- a/src/Config.php
+++ b/src/Config.php
@@ -58,7 +58,7 @@ class Config
         $cUserAgent = Util::createCString($this->userAgent, $scope);
         $cTempDirectory = Util::createCString($this->tempDirectory, $scope);
 
-        $cConfig = $ffi->new('Config');
+        $cConfig = $ffi->new('UplinkConfig');
         $cConfig->user_agent = $cUserAgent;
         $cConfig->dial_timeout_milliseconds = $this->dialTimeoutMilliseconds;
         $cConfig->temp_directory = $cTempDirectory;

--- a/src/Download.php
+++ b/src/Download.php
@@ -30,7 +30,7 @@ class Download
     private FFI $ffi;
 
     /**
-     * The C struct of type Download
+     * The C struct of type UplinkDownload
      */
     private CData $cDownload;
 
@@ -54,8 +54,8 @@ class Download
 
     public function info(): ObjectInfo
     {
-        $objectResult = $this->ffi->download_info($this->cDownload);
-        $scope = Scope::exit(fn() => $this->ffi->free_object_result($objectResult));
+        $objectResult = $this->ffi->uplink_download_info($this->cDownload);
+        $scope = Scope::exit(fn() => $this->ffi->uplink_free_object_result($objectResult));
 
         Util::throwIfErrorResult($objectResult);
 
@@ -79,8 +79,8 @@ class Download
             $buffer = str_repeat("\0", $length);
         }
 
-        $readResult = $this->ffi->download_read($this->cDownload, $buffer, $length);
-        $scope = Scope::exit(fn() => $this->ffi->free_read_result($readResult));
+        $readResult = $this->ffi->uplink_download_read($this->cDownload, $buffer, $length);
+        $scope = Scope::exit(fn() => $this->ffi->uplink_free_read_result($readResult));
 
         if ($readResult->error !== null && $readResult->error->code === -1) {
             // done
@@ -130,7 +130,7 @@ class Download
         // See https://www.php.net/manual/en/function.error-get-last.php#113518
         // This will never be called because of the 0.
         set_error_handler(null, 0);
-        $scope = Scope::exit(fn() => restore_error_handler());
+        $scope = Scope::exit('restore_error_handler');
 
         $totalWritten = 0;
 

--- a/src/DownloadOptions.php
+++ b/src/DownloadOptions.php
@@ -32,7 +32,7 @@ class DownloadOptions
      */
     public function toCStruct(FFI $ffi): CData
     {
-        $cDownloadOptions = $ffi->new('DownloadOptions');
+        $cDownloadOptions = $ffi->new('UplinkDownloadOptions');
         $cDownloadOptions->offset = $this->offset;
         $cDownloadOptions->length = $this->length ?? -1; // if negative, it will read until the end of the blob.
 

--- a/src/EncryptionKey.php
+++ b/src/EncryptionKey.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Storj\Uplink;
+
+use FFI;
+use FFI\CData;
+use Storj\Uplink\Internal\Scope;
+
+class EncryptionKey
+{
+    /**
+     * With libuplink.so and header files loaded
+     */
+    private FFI $ffi;
+
+    /**
+     * The associated C struct of type UplinkEncryptionKey
+     */
+    private CData $cEncryptionKey;
+
+    /**
+     * To free memory when this object is done
+     */
+    private Scope $scope;
+
+    public function __construct(FFI $ffi, CData $cEncryptionKey, Scope $scope)
+    {
+        $this->ffi = $ffi;
+        $this->cEncryptionKey = $cEncryptionKey;
+        $this->scope = $scope;
+    }
+
+    /**
+     * @internal unsafe
+     */
+    public function getCStruct(): CData
+    {
+        return $this->cEncryptionKey;
+    }
+}

--- a/src/Exception/BandwidthLimitExceeded.php
+++ b/src/Exception/BandwidthLimitExceeded.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Storj\Uplink\Exception;
+
+class BandwidthLimitExceeded extends UplinkException
+{
+}

--- a/src/Exception/UplinkException.php
+++ b/src/Exception/UplinkException.php
@@ -14,6 +14,7 @@ abstract class UplinkException extends Exception
         0x03 => Cancelled::class,
         0x04 => InvalidHandle::class,
         0x05 => TooManyRequests::class,
+        0x06 => BandwidthLimitExceeded::class,
 
         0x10 => Bucket\InvalidBucketName::class,
         0x11 => Bucket\BucketAlreadyExists::class,

--- a/src/Internal/Scope.php
+++ b/src/Internal/Scope.php
@@ -55,7 +55,7 @@ class Scope
 
     public function __destruct()
     {
-        foreach ($this->handlers as $handler) {
+        foreach (array_reverse($this->handlers) as $handler) {
             $handler();
         }
     }

--- a/src/ListObjectsOptions.php
+++ b/src/ListObjectsOptions.php
@@ -91,7 +91,7 @@ class ListObjectsOptions
      */
     public function toCStruct(FFI $ffi, Scope $scope): CData
     {
-        $cListObjectsOptions = $ffi->new('ListObjectsOptions');
+        $cListObjectsOptions = $ffi->new('UplinkListObjectsOptions');
 
         $cListObjectsOptions->prefix = Util::createCString($this->prefix, $scope);
         $cListObjectsOptions->cursor = Util::createCString($this->cursor, $scope);

--- a/src/ObjectInfo.php
+++ b/src/ObjectInfo.php
@@ -59,7 +59,7 @@ class ObjectInfo
     }
 
     /**
-     * @param CData $cCustomMetaData C struct of type CustomMetaData
+     * @param CData $cCustomMetaData C struct of type UplinkCustomMetaData
      * @return string[] hash map
      */
     private static function createCustomMetaDataFromCStruct(

--- a/src/Permission.php
+++ b/src/Permission.php
@@ -140,7 +140,7 @@ class Permission
      */
     public function toCStruct(FFI $ffi): CData
     {
-        $cPermission = $ffi->new('Permission');
+        $cPermission = $ffi->new('UplinkPermission');
         $cPermission->allow_download = $this->allowDownload;
         $cPermission->allow_upload = $this->allowUpload;
         $cPermission->allow_list = $this->allowList;

--- a/src/SharePrefix.php
+++ b/src/SharePrefix.php
@@ -47,7 +47,7 @@ class SharePrefix
     {
         $count = count($sharePrefixes);
 
-        $cSharePrefixesType = FFI::arrayType($ffi->type('SharePrefix'), [$count]);
+        $cSharePrefixesType = FFI::arrayType($ffi->type('UplinkSharePrefix'), [$count]);
         $cSharePrefixes = $ffi->new($cSharePrefixesType);
 
         foreach (Util::it($count) as $i) {

--- a/src/Upload.php
+++ b/src/Upload.php
@@ -23,7 +23,7 @@ class Upload
     private FFI $ffi;
 
     /**
-     * The associated C struct of type Upload
+     * The associated C struct of type UplinkUpload
      */
     private CData $cUpload;
 
@@ -47,8 +47,8 @@ class Upload
      */
     public function write(string $content): void
     {
-        $writeResult = $this->ffi->upload_write($this->cUpload, $content, strlen($content));
-        $scope = Scope::exit(fn() => $this->ffi->free_write_result($writeResult));
+        $writeResult = $this->ffi->uplink_upload_write($this->cUpload, $content, strlen($content));
+        $scope = Scope::exit(fn() => $this->ffi->uplink_free_write_result($writeResult));
 
         Util::throwIfErrorResult($writeResult);
     }
@@ -66,7 +66,7 @@ class Upload
         // See https://www.php.net/manual/en/function.error-get-last.php#113518
         // This will never be called because of the 0.
         set_error_handler(null, 0);
-        $scope = Scope::exit(fn() => restore_error_handler());
+        $scope = Scope::exit('restore_error_handler');
 
         while (!feof($resource)) {
             $content = @fread($resource, $chunkSize);
@@ -98,8 +98,8 @@ class Upload
      */
     public function commit(): void
     {
-        $pError = $this->ffi->upload_commit($this->cUpload);
-        $scope = Scope::exit(fn() => $this->ffi->free_error($pError));
+        $pError = $this->ffi->uplink_upload_commit($this->cUpload);
+        $scope = Scope::exit(fn() => $this->ffi->uplink_free_error($pError));
 
         Util::throwIfError($pError);
     }
@@ -110,8 +110,8 @@ class Upload
      */
     public function abort(): void
     {
-        $pError = $this->ffi->upload_abort($this->cUpload);
-        $scope = Scope::exit(fn() => $this->ffi->free_error($pError));
+        $pError = $this->ffi->uplink_upload_abort($this->cUpload);
+        $scope = Scope::exit(fn() => $this->ffi->uplink_free_error($pError));
 
         Util::throwIfError($pError);
     }
@@ -121,8 +121,8 @@ class Upload
      */
     public function info(): ObjectInfo
     {
-        $objectResult = $this->ffi->upload_info($this->cUpload);
-        $scope = Scope::exit(fn() => $this->ffi->free_object_result($objectResult));
+        $objectResult = $this->ffi->uplink_upload_info($this->cUpload);
+        $scope = Scope::exit(fn() => $this->ffi->uplink_free_object_result($objectResult));
 
         Util::throwIfErrorResult($objectResult);
 
@@ -138,7 +138,7 @@ class Upload
     {
         $count = count($customMetadata);
 
-        $entriesType = FFI::arrayType($this->ffi->type('CustomMetadataEntry'), [$count]);
+        $entriesType = FFI::arrayType($this->ffi->type('UplinkCustomMetadataEntry'), [$count]);
         $cEntries = $this->ffi->new($entriesType, false);
         $scope = Scope::exit(fn() => FFI::free($cEntries));
 
@@ -157,12 +157,12 @@ class Upload
             $i++;
         }
 
-        $cCustomMetadata = $this->ffi->new('CustomMetadata');
+        $cCustomMetadata = $this->ffi->new('UplinkCustomMetadata');
         $cCustomMetadata->count = $count;
         $cCustomMetadata->entries = $cEntries;
 
-        $pError = $this->ffi->upload_set_custom_metadata($this->cUpload, $cCustomMetadata);
-        $scope->onExit(fn() => $this->ffi->free_error($pError));
+        $pError = $this->ffi->uplink_upload_set_custom_metadata($this->cUpload, $cCustomMetadata);
+        $scope->onExit(fn() => $this->ffi->uplink_free_error($pError));
 
         Util::throwIfError($pError);
     }

--- a/test/AccessTest.php
+++ b/test/AccessTest.php
@@ -29,5 +29,15 @@ class AccessTest extends TestCase
         $project = Util::access()->openProject(
             (new Config())->withDialTimeoutMilliseconds(1)
         );
+
+        $project->ensureBucket('asdfasdf');
+    }
+
+    public function testSatteliteAddress(): void
+    {
+        self::assertEquals(
+            Util::getSatelliteAddress(),
+            Util::access()->satteliteAddress()
+        );
     }
 }

--- a/test/EncryptionKeyTest.php
+++ b/test/EncryptionKeyTest.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace Storj\Uplink\Test;
+
+use PHPUnit\Framework\TestCase;
+use Storj\Uplink\Exception\Object\ObjectNotFound;
+use Storj\Uplink\Permission;
+use Storj\Uplink\SharePrefix;
+
+class EncryptionKeyTest extends TestCase
+{
+    public function testDeriveEncryptionKeyIsNotEmpty(): void
+    {
+        $encryptionKey = Util::uplink()->deriveEncryptionKey('mypassphrase', 'mysalt');
+        self::assertNotNull($encryptionKey);
+    }
+
+    /**
+     * https://godoc.org/storj.io/uplink#hdr-Multitenancy_in_a_Single_Application_Bucket
+     */
+    public function testWrongPasswordCantDownload(): void
+    {
+        $bucket = 'bucket1';
+        $prefix = 'prefix1';
+        $object = 'object1';
+
+        Util::emptyAccess();
+        $rootAccess = Util::uplink()->requestAccessWithPassphrase(
+            Util::getSatelliteAddress(),
+            getenv('GATEWAY_0_API_KEY'),
+            ''
+        );
+        $rootProject = $rootAccess->openProject();
+        $encryptionKey = Util::uplink()->deriveEncryptionKey('mypassphrase1', 'mysalt');
+        $rootProject->createBucket($bucket);
+
+        $limitedAccess = $rootAccess->share(Permission::fullPermission(), new SharePrefix($bucket, "$prefix/"));
+        $limitedAccess->overrideEncryptionKey(
+            $bucket,
+            "$prefix/",
+            $encryptionKey
+        );
+        $project = $limitedAccess->openProject();
+        $upload = $project->uploadObject($bucket, "$prefix/$object");
+        $upload->write('content1');
+        $upload->commit();
+
+        $imposterLimitedAccess = Util::uplink()->requestAccessWithPassphrase(
+            Util::getSatelliteAddress(),
+            getenv('GATEWAY_0_API_KEY'),
+            ''
+        )->share(Permission::fullPermission(), new SharePrefix($bucket, "$prefix/"));
+
+        $imposterEncryptionKey = Util::uplink()->deriveEncryptionKey('mypassphrase2', 'mysalt');
+        $imposterLimitedAccess->overrideEncryptionKey(
+            $bucket,
+            "$prefix/",
+            $imposterEncryptionKey
+        );
+
+        $imposterProject = $imposterLimitedAccess->openProject();
+        self::expectException(ObjectNotFound::class);
+        $download = $imposterProject->downloadObject($bucket, "$prefix/$object");
+    }
+
+    public function testWrongSaltCantDownload(): void
+    {
+        $bucket = 'bucket1';
+        $prefix = 'prefix1';
+        $object = 'object1';
+
+        Util::emptyAccess();
+        $rootAccess = Util::uplink()->requestAccessWithPassphrase(
+            Util::getSatelliteAddress(),
+            getenv('GATEWAY_0_API_KEY'),
+            ''
+        );
+        $rootProject = $rootAccess->openProject();
+        $encryptionKey = Util::uplink()->deriveEncryptionKey('mypassphrase', 'mysalt1');
+        $rootProject->createBucket($bucket);
+
+        $limitedAccess = $rootAccess->share(Permission::fullPermission(), new SharePrefix($bucket, "$prefix/"));
+        $limitedAccess->overrideEncryptionKey(
+            $bucket,
+            "$prefix/",
+            $encryptionKey
+        );
+        $project = $limitedAccess->openProject();
+        $upload = $project->uploadObject($bucket, "$prefix/$object");
+        $upload->write('content1');
+        $upload->commit();
+
+        $imposterLimitedAccess = Util::uplink()->requestAccessWithPassphrase(
+            Util::getSatelliteAddress(),
+            getenv('GATEWAY_0_API_KEY'),
+            ''
+        )->share(Permission::fullPermission(), new SharePrefix($bucket, "$prefix/"));
+
+        $imposterEncryptionKey = Util::uplink()->deriveEncryptionKey('mypassphrase', 'mysalt2');
+        $imposterLimitedAccess->overrideEncryptionKey(
+            $bucket,
+            "$prefix/",
+            $imposterEncryptionKey
+        );
+
+        $imposterProject = $imposterLimitedAccess->openProject();
+        self::expectException(ObjectNotFound::class);
+        $download = $imposterProject->downloadObject($bucket, "$prefix/$object");
+    }
+
+    public function testHappyFlow(): void
+    {
+        $bucket = 'bucket1';
+        $prefix = 'prefix1';
+        $object = 'object1';
+
+        Util::emptyAccess();
+        $rootAccess = Util::uplink()->requestAccessWithPassphrase(
+            Util::getSatelliteAddress(),
+            getenv('GATEWAY_0_API_KEY'),
+            ''
+        );
+        $rootProject = $rootAccess->openProject();
+        $encryptionKey = Util::uplink()->deriveEncryptionKey('mypassphrase1', 'mysalt');
+        $rootProject->createBucket($bucket);
+
+        $limitedAccess1 = $rootAccess->share(Permission::fullPermission(), new SharePrefix($bucket, "$prefix/"));
+        $limitedAccess1->overrideEncryptionKey(
+            $bucket,
+            "$prefix/",
+            $encryptionKey
+        );
+        $project1 = $limitedAccess1->openProject();
+        $upload = $project1->uploadObject($bucket, "$prefix/$object");
+        $upload->write('content1');
+        $upload->commit();
+
+        $limitedAccess2 = Util::uplink()->requestAccessWithPassphrase(
+            Util::getSatelliteAddress(),
+            getenv('GATEWAY_0_API_KEY'),
+            ''
+        )->share(Permission::fullPermission(), new SharePrefix($bucket, "$prefix/"));
+
+        $imposterEncryptionKey = Util::uplink()->deriveEncryptionKey('mypassphrase1', 'mysalt');
+        $limitedAccess2->overrideEncryptionKey(
+            $bucket,
+            "$prefix/",
+            $imposterEncryptionKey
+        );
+
+        $project2 = $limitedAccess2->openProject();
+        $download = $project2->downloadObject($bucket, "$prefix/$object");
+        $content = $download->readAll();
+
+        self::assertEquals('content1', $content);
+    }
+}

--- a/test/UplinkTest.php
+++ b/test/UplinkTest.php
@@ -11,8 +11,7 @@ class UplinkTest extends TestCase
 {
     public function testAccessWithPassPhrase(): void
     {
-        $uplink = Uplink::create();
-        $access = $uplink->requestAccessWithPassphrase(
+        $access = Util::uplink()->requestAccessWithPassphrase(
             Util::getSatelliteAddress(),
             getenv('GATEWAY_0_API_KEY'),
             'mypassphrase'
@@ -23,7 +22,7 @@ class UplinkTest extends TestCase
 
     public function testAccessWithAccessString(): void
     {
-        $uplink = Uplink::create();
+        $uplink = Util::uplink();
         $access = $uplink->requestAccessWithPassphrase(
             Util::getSatelliteAddress(),
             getenv('GATEWAY_0_API_KEY'),
@@ -37,7 +36,7 @@ class UplinkTest extends TestCase
 
     public function testAccessWithConfig(): void
     {
-        $access = Uplink::create()->requestAccessWithPassphrase(
+        $access = Util::uplink()->requestAccessWithPassphrase(
             Util::getSatelliteAddress(),
             getenv('GATEWAY_0_API_KEY'),
             'mypassphrase',
@@ -51,7 +50,7 @@ class UplinkTest extends TestCase
     {
         $this->expectException(UplinkException::class);
 
-        $access = Uplink::create()->requestAccessWithPassphrase(
+        $access = Util::uplink()->requestAccessWithPassphrase(
             Util::getSatelliteAddress(),
             getenv('GATEWAY_0_API_KEY'),
             'mypassphrase',


### PR DESCRIPTION
Updates uplink-c, renames c bindings and implements added functions.

No BC break in the PHP API.

The added EncryptionKey for multi-tenant buckets is not securing the objects as I would expect. I asked for help in slack. 
=> update: this is fixed, waiting on tag of https://github.com/storj/uplink-c/commit/f6073cab8a5a9c548a5e8589593df08fbb3636c8
=> update: uplink-c 1.2.2 was tagged and updated here in uplink-php