### PR TITLE
Download: fix downloading >64MB

### DIFF
--- a/src/CursoredDownload.php
+++ b/src/CursoredDownload.php
@@ -15,16 +15,17 @@ class CursoredDownload extends Download
 
     private bool $done = false;
 
-    public function read(int $length = self::CHUNKSIZE, ?string &$buffer = null): string
+    public function readChunkToString(string &$buffer): ReadResult
     {
-        $read = parent::read($length, $buffer);
+        $readResult = parent::readChunkToString($buffer);
 
-        $this->offset += strlen($read);
-        if ($read === '') {
+        $this->offset += $readResult->getLength();
+
+        if ($readResult->isEof()) {
             $this->done = true;
         }
 
-        return $read;
+        return $readResult;
     }
 
     public function getOffset(): int

--- a/src/ReadResult.php
+++ b/src/ReadResult.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Storj\Uplink;
+
+/**
+ * Result of read operation
+ */
+class ReadResult
+{
+    private string $bytes;
+
+    private bool $eof;
+
+    public function __construct(string $bytes, bool $eof)
+    {
+        $this->bytes = $bytes;
+        $this->eof = $eof;
+    }
+
+    public function getBytes(): string
+    {
+        return $this->bytes;
+    }
+
+    public function getLength(): int
+    {
+        return strlen($this->bytes);
+    }
+
+    public function isEof(): bool
+    {
+        return $this->eof;
+    }
+}

--- a/test/LargeObjectMemoryUsageTest.php
+++ b/test/LargeObjectMemoryUsageTest.php
@@ -5,7 +5,7 @@ namespace Storj\Uplink\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @group memory-usage
+ * @group large-object
  */
 class LargeObjectMemoryUsageTest extends TestCase
 {
@@ -13,7 +13,7 @@ class LargeObjectMemoryUsageTest extends TestCase
     {
         self::assertLessThan(20_000_000, memory_get_peak_usage());
 
-        $inputFile = self::create40mbFile();
+        $inputFile = Util::createTmpFile(40_000_000);
         $outputFile = tmpfile();
 
         $project = Util::emptyAccess()->openProject();
@@ -43,21 +43,5 @@ class LargeObjectMemoryUsageTest extends TestCase
             hash_file('sha256', $inputFileName),
             hash_file('sha256', $outputFileName)
         );
-    }
-
-    /**
-     * @return resource
-     */
-    private static function create40mbFile()
-    {
-        $size = 0;
-        $chunksize = 8_000;
-        $resource = tmpfile();
-        while ($size < 40_000_000) {
-            fwrite($resource, random_bytes($chunksize));
-            $size += $chunksize;
-        }
-        rewind($resource);
-        return $resource;
     }
 }

--- a/test/SegmentBoundaryTest.php
+++ b/test/SegmentBoundaryTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Storj\Uplink\Test;
+
+use PHPUnit\Framework\TestCase;
+use Storj\Uplink\Project;
+
+/**
+ * Storj internally uses 64 MB segments.
+ * This test verifies that downloading works when crossing a segment boundary.
+ *
+ * @group large-object
+ */
+class SegmentBoundaryTest extends TestCase
+{
+    private const SIZE = 96_000_000;
+
+    private string $fileSha256;
+
+    private Project $project;
+
+    protected function setUp(): void
+    {
+        $inputFile = Util::createTmpFile(self::SIZE);
+        $inputFileName = stream_get_meta_data($inputFile)['uri'];
+        $this->fileSha256 = hash_file('sha256', $inputFileName);
+
+        $this->project = Util::emptyAccess()->openProject();
+        $this->project->createBucket('phpunit');
+
+        $upload = $this->project->uploadObject('phpunit', 'MultipleSegmentsTest');
+        $upload->writeFromResource($inputFile);
+        $upload->commit();
+    }
+
+    public function testDownloadLargeFile(): void
+    {
+        $outputFile = tmpfile();
+
+        $download = $this->project->downloadObject('phpunit', 'MultipleSegmentsTest');
+        $download->readIntoResource($outputFile);
+
+        self::assertEquals(
+            self::SIZE,
+            fstat($outputFile)['size']
+        );
+
+        $outputFileName = stream_get_meta_data($outputFile)['uri'];
+
+        self::assertEquals(
+            $this->fileSha256,
+            hash_file('sha256', $outputFileName)
+        );
+    }
+}

--- a/test/Util.php
+++ b/test/Util.php
@@ -95,4 +95,19 @@ class Util
             $project->deleteBucketWithObjects($bucketName);
         }
     }
+
+    /**
+     * @return false|resource
+     */
+    public static function createTmpFile(int $size, int $chunksize = 8_000)
+    {
+        $resource = tmpfile();
+        while ($size > 0) {
+            $length = min($size, $chunksize);
+            fwrite($resource, random_bytes($length));
+            $size -= $length;
+        }
+        rewind($resource);
+        return $resource;
+    }
 }


### PR DESCRIPTION
On top of https://github.com/storj-thirdparty/uplink-php/pull/13 to fix build issue. So only review the second commit.

When uplink_download_read() is called the last time for a segment boundry, it returns an empty result which was interpreted as an end condition.

With this change only EOF ends the read loop.

https://github.com/storj-thirdparty/nextcloud-app/issues/4