### PR TITLE
objectinfo: simpler constructor

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,6 +42,7 @@ pipeline {
                     // get owner UID of working directory to run commands as that user
                     def userId = sh(script: "stat -c '%u' .", returnStdout: true).trim()
                     sh "useradd --create-home --uid ${userId} jenkins"
+                    sh "chown -R jenkins /go/pkg/mod"
 
                     sh 'su jenkins -c "make build-x64"'
                     stash(name: "build-x64", includes: "build/")
@@ -57,7 +58,7 @@ pipeline {
             agent {
                 dockerfile {
                     dir 'docker/go-docker'
-                    args '--volume /var/run/docker.sock:/var/run/docker.sock --volume /tmp/gomod:/go/pkg/mod --user root:root'
+                    args '--volume /var/run/docker.sock:/var/run/docker.sock --user root:root'
                 }
             }
             steps {

--- a/Makefile
+++ b/Makefile
@@ -21,12 +21,12 @@ build/libuplink-x86_64-linux.so tmp/uplink-c/.build/uplink/uplink.h tmp/uplink-c
 
 build/libuplink-aarch64-linux.so: tmp/uplink-c
 	docker run --rm \
-		-v $(GOMODCACHE):/go/pkg/mod \
+		-v /tmp/gomod:/go/pkg/mod \
 		-v $(PWD)/tmp:$(PWD)/tmp \
 		--workdir $(PWD)/tmp/uplink-c \
 		-e CGO_ENABLED=1 \
-		docker.elastic.co/beats-dev/golang-crossbuild:1.17.1-arm \
-		--build-cmd "useradd --create-home --uid $(UID) jenkins && su jenkins -c 'PATH=\$$PATH:/go/bin:/usr/local/go/bin make build'" \
+		docker.elastic.co/beats-dev/golang-crossbuild:1.17.3-arm \
+		--build-cmd "useradd --create-home --uid $(UID) jenkins && chown -R jenkins /go/pkg/mod && su jenkins -c 'PATH=\$$PATH:/go/bin:/usr/local/go/bin make build'" \
 		-p "linux/arm64"
 	mkdir -p build
 	cat ./tmp/uplink-c/.build/libuplink.so > build/libuplink-aarch64-linux.so

--- a/src/Download.php
+++ b/src/Download.php
@@ -58,7 +58,7 @@ class Download
 
         Util::throwIfErrorResult($objectResult);
 
-        return new ObjectInfo($objectResult->object, true, true);
+        return ObjectInfo::fromCStruct($objectResult->object, true, true);
     }
 
     /**

--- a/src/ObjectInfo.php
+++ b/src/ObjectInfo.php
@@ -35,13 +35,28 @@ class ObjectInfo
     private ?array $customMetaData;
 
     /**
-     * @internal
+     * @param string[]|null $customMetaData
      */
     public function __construct(
+        string $key,
+        bool $isPrefix,
+        ?SystemMetadata $systemMetadata,
+        ?array $customMetaData
+    ) {
+        $this->key = $key;
+        $this->isPrefix = $isPrefix;
+        $this->systemMetadata = $systemMetadata;
+        $this->customMetaData = $customMetaData;
+    }
+    
+    /**
+     * @internal
+     */
+    public static function fromCStruct(
         CData $cObjectInfo,
         bool $includeSystemMetadata,
         bool $includeCustomMetaData
-    ) {
+    ): self {
         $systemMetaData = null;
         if ($includeSystemMetadata) {
             $systemMetaData = new SystemMetadata($cObjectInfo->system);
@@ -52,10 +67,12 @@ class ObjectInfo
             $customMetaData = self::createCustomMetaDataFromCStruct($cObjectInfo->custom);
         }
 
-        $this->key = FFI::string($cObjectInfo->key);
-        $this->isPrefix = $cObjectInfo->is_prefix;
-        $this->systemMetadata = $systemMetaData;
-        $this->customMetaData = $customMetaData;
+        return new self(
+            FFI::string($cObjectInfo->key),
+            $cObjectInfo->is_prefix,
+            $systemMetaData,
+            $customMetaData
+        );
     }
 
     /**

--- a/src/Project.php
+++ b/src/Project.php
@@ -234,7 +234,7 @@ class Project
             return null;
         }
 
-        return new ObjectInfo($objectResult->object, true, true);
+        return ObjectInfo::fromCStruct($objectResult->object, true, true);
     }
 
     /**
@@ -248,7 +248,7 @@ class Project
 
         Util::throwIfErrorResult($objectResult);
 
-        return new ObjectInfo($objectResult->object, true, true);
+        return ObjectInfo::fromCStruct($objectResult->object, true, true);
     }
 
     /**
@@ -274,7 +274,7 @@ class Project
             $innerScope = Scope::exit(fn() => $this->ffi->uplink_free_object($pObject));
 
             // Why do we do [0] here but not when dereferencing ObjectResult::object?
-            yield new ObjectInfo(
+            yield ObjectInfo::fromCStruct(
                 $pObject[0],
                 $listObjectsOptions->includeSystemMetadata(),
                 $listObjectsOptions->includeCustomMetadata()

--- a/src/Upload.php
+++ b/src/Upload.php
@@ -142,7 +142,7 @@ class Upload
 
         Util::throwIfErrorResult($objectResult);
 
-        return new ObjectInfo($objectResult->object, true, true);
+        return ObjectInfo::fromCStruct($objectResult->object, true, true);
     }
 
     /**


### PR DESCRIPTION
Remove the C struct from the ObjectInfo constructor, so that ObjectInfo
can be instantiated from user code. This allow the user to use this
object in caching logic.

example usage: https://github.com/storj-thirdparty/nextcloud-app/pull/15