### PR TITLE
config: set temp storage to in-memory

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -20,13 +20,14 @@ class Config
 
     /**
      * Where to save data during downloads to use less memory.
-     * Use "inmemory" to store in-memory
+     * For example set it to PHP's sys_get_temp_dir().
+     * Use "inmemory" to store in-memory.
      */
     private string $tempDirectory;
 
     public function __construct()
     {
-        $this->tempDirectory = sys_get_temp_dir();
+        $this->tempDirectory = "inmemory";
     }
 
     public function withUserAgent(string $userAgent): self


### PR DESCRIPTION
This seems a better default for a PHP web app.