### PR TITLE
add dlerror() information

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -147,7 +147,7 @@ pipeline {
         stage('PHPStan') {
             agent {
                 docker {
-                    image 'ghcr.io/phpstan/phpstan:1.0.2'
+                    image 'ghcr.io/phpstan/phpstan:1.8.1'
                     args '--mount type=volume,source=phpstan-cache,destination=/tmp/phpstan ' +
                         '--user root:root ' +
                         "--entrypoint='' "

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,14 +7,6 @@ parameters:
 		- '/Call to an undefined method FFI::.*/'
 		- '/Access to an undefined property FFI\\CData::.*/'
 		-
-			message: '/Binary operation "-" between numeric-string and string results in an error./'
-			paths:
-			- test/ListObjectsTest.php
-		-
-			message: "#^Binary operation \"\\-\" between int and string results in an error\\.$#"
-			count: 1
-			path: test/StatObjectTest.php
-		-
 			message: "#^Property Storj\\\\Uplink\\\\Access\\:\\:\\$scope is never read, only written\\.$#"
 			count: 1
 			path: src/Access.php


### PR DESCRIPTION
When the uplink library cannot be loaded, there is currently a generic
message originating from PHP. This is in all PHP versions.

This change adds extra information which will help the user diagnose the
issue.

Example of old output:

```
Fatal error: Uncaught FFI\Exception: Failed loading '/app/build/libuplink-x86_64-linux.so' in /app/src/Uplink.php:42
```

Example of new output:

```
Fatal error: Uncaught FFI\Exception: Failed loading '/app/build/libuplink-x86_64-linux.so'. /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by /app/build/libuplink-x86_64-linux.so) in /app/src/Uplink.php:60
```

Fixes https://github.com/storj-thirdparty/uplink-php/issues/21