### PR TITLE
Add composer repository

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -18,5 +18,5 @@ New release after uplink-c version bump
 - Change the uplink-c git tag in ./build.sh
 - Let [jenkins](https://build.dev.storj.io/blue/organizations/jenkins/uplink-php) build the artifact
 - Create a git tag
-- Upload the artifact to GitHub on the [releases page](https://github.com/storj-thirdparty/uplink-php/releases)
-- Update [README.md#installation](./README.md#installation) with the tag and artifact URL
+- Upload the artifact to GitHub on the [releases page](https://github.com/storj-thirdparty/uplink-php/releases) or to [Linksharing](https://link.storjshare.io/raw/jxmgbsqc4k2bbhuv27556pcoh7ra/uplink-php-releases/).
+- Update [packages.json](./packages.json) with the version tag and artifact URL

--- a/README.md
+++ b/README.md
@@ -39,34 +39,8 @@ ffi.enable=true
 
 ```
 composer config repositories.storj/uplink '{
-    "type": "package",
-    "package": {
-        "name": "storj/uplink",
-        "version": "1.3.0",
-        "license": "MIT/Expat",
-        "dist": {
-            "url": "https://link.storjshare.io/raw/jxmgbsqc4k2bbhuv27556pcoh7ra/uplink-php-releases/uplink-php-v1.3.0.zip",
-            "type": "zip"
-        },
-        "autoload": {
-            "psr-4": {
-                "Storj\\Uplink\\": "src/"
-            }
-        },
-        "autoload-dev": {
-            "psr-4": {
-                "Storj\\Uplink\\Test\\": "test/"
-            }
-        },
-        "require": {
-            "php": ">=7.4",
-            "ext-ffi": "*",
-            "psr/http-message": "^1.0"
-        },
-        "require-dev": {
-            "phpunit/phpunit": "^9.2"
-        }
-    }
+    "type": "composer",
+    "url": "https://raw.githubusercontent.com/storj-thirdparty/uplink-php/main/"
 }' &&
 composer require storj/uplink
 ```

--- a/packages.json
+++ b/packages.json
@@ -1,0 +1,186 @@
+{
+    "packages": {
+        "storj/uplink": {
+            "0.1.0": {
+                "name": "storj/uplink",
+                "version": "0.1.0",
+                "dist": {
+                    "url": "https://github.com/storj-thirdparty/uplink-php/releases/download/v0.1.0/release.zip",
+                    "type": "zip"
+                },
+                "description": "Storj DCS client",
+                "homepage": "https://github.com/storj-thirdparty/uplink-php",
+                "type": "library",
+                "license": "MIT/Expat",
+                "authors": [
+                    {
+                        "name": "Erik van Velzen",
+                        "email": "erik@evanv.nl"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Storj\\Uplink\\": "src/"
+                    }
+                },
+                "autoload-dev": {
+                    "psr-4": {
+                        "Storj\\Uplink\\Test\\": "test/"
+                    }
+                },
+                "require": {
+                    "php": ">=7.4",
+                    "ext-ffi": "*",
+                    "psr/http-message": "^1.0"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "^9.2"
+                }
+            },
+            "1.0.0": {
+                "name": "storj/uplink",
+                "version": "1.0.0",
+                "dist": {
+                    "url": "https://link.storjshare.io/raw/jxmgbsqc4k2bbhuv27556pcoh7ra/uplink-php-releases/uplink-php-v1.0.0.zip",
+                    "type": "zip"
+                },
+                "description": "Storj DCS client",
+                "homepage": "https://github.com/storj-thirdparty/uplink-php",
+                "type": "library",
+                "license": "MIT/Expat",
+                "authors": [
+                    {
+                        "name": "Erik van Velzen",
+                        "email": "erik@evanv.nl"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Storj\\Uplink\\": "src/"
+                    }
+                },
+                "autoload-dev": {
+                    "psr-4": {
+                        "Storj\\Uplink\\Test\\": "test/"
+                    }
+                },
+                "require": {
+                    "php": ">=7.4",
+                    "ext-ffi": "*",
+                    "psr/http-message": "^1.0"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "^9.2"
+                }
+            },
+            "1.1.0": {
+                "name": "storj/uplink",
+                "version": "1.1.0",
+                "dist": {
+                    "url": "https://link.storjshare.io/raw/jxmgbsqc4k2bbhuv27556pcoh7ra/uplink-php-releases/uplink-php-v1.1.0.zip",
+                    "type": "zip"
+                },
+                "description": "Storj DCS client",
+                "homepage": "https://github.com/storj-thirdparty/uplink-php",
+                "type": "library",
+                "license": "MIT/Expat",
+                "authors": [
+                    {
+                        "name": "Erik van Velzen",
+                        "email": "erik@evanv.nl"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Storj\\Uplink\\": "src/"
+                    }
+                },
+                "autoload-dev": {
+                    "psr-4": {
+                        "Storj\\Uplink\\Test\\": "test/"
+                    }
+                },
+                "require": {
+                    "php": ">=7.4",
+                    "ext-ffi": "*",
+                    "psr/http-message": "^1.0"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "^9.2"
+                }
+            },
+            "1.2.0": {
+                "name": "storj/uplink",
+                "version": "1.2.0",
+                "dist": {
+                    "url": "https://link.storjshare.io/raw/jxmgbsqc4k2bbhuv27556pcoh7ra/uplink-php-releases/uplink-php-v1.2.0.zip",
+                    "type": "zip"
+                },
+                "description": "Storj DCS client",
+                "homepage": "https://github.com/storj-thirdparty/uplink-php",
+                "type": "library",
+                "license": "MIT/Expat",
+                "authors": [
+                    {
+                        "name": "Erik van Velzen",
+                        "email": "erik@evanv.nl"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Storj\\Uplink\\": "src/"
+                    }
+                },
+                "autoload-dev": {
+                    "psr-4": {
+                        "Storj\\Uplink\\Test\\": "test/"
+                    }
+                },
+                "require": {
+                    "php": ">=7.4",
+                    "ext-ffi": "*",
+                    "psr/http-message": "^1.0"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "^9.2"
+                }
+            },
+            "1.3.0": {
+                "name": "storj/uplink",
+                "version": "1.3.0",
+                "dist": {
+                    "url": "https://link.storjshare.io/raw/jxmgbsqc4k2bbhuv27556pcoh7ra/uplink-php-releases/uplink-php-v1.3.0.zip",
+                    "type": "zip"
+                },
+                "description": "Storj DCS client",
+                "homepage": "https://github.com/storj-thirdparty/uplink-php",
+                "type": "library",
+                "license": "MIT/Expat",
+                "authors": [
+                    {
+                        "name": "Erik van Velzen",
+                        "email": "erik@evanv.nl"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Storj\\Uplink\\": "src/"
+                    }
+                },
+                "autoload-dev": {
+                    "psr-4": {
+                        "Storj\\Uplink\\Test\\": "test/"
+                    }
+                },
+                "require": {
+                    "php": ">=7.4",
+                    "ext-ffi": "*",
+                    "psr/http-message": "^1.0"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "^9.2"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This adds a packages.json file which can be read over HTTP from Github by Composer. The previous installation method still works. This packages.json file is maintained manually.

This makes Uplink-PHP behave more like a normal PHP library. This has advantages for a PHP developer managing their project:

1. `composer update` can automatically update Uplink-PHP to the latest version

2. If we release versions which depend on different PHP versions or different PHP libraries, Composer will select the version most compatible with your project.

   Unfortunately composer currently only does a [limited check on platform compatibility](https://getcomposer.org/doc/01-basic-usage.md#platform-packages) which does not include OS type, instruction set architecture, and glibc version.

I tested this in a project with commands:

```
composer config repositories.storj/uplink '{
    "type": "composer",
    "url": "https://raw.githubusercontent.com/storj-thirdparty/uplink-php/composer-repository/"
}' &&
composer require storj/uplink
```

Then it installs v1.3.0. Then I tried out all the released versions:

```
composer require storj/uplink:0.1.0
composer require storj/uplink:1.0.0
composer require storj/uplink:1.1.0
composer require storj/uplink:1.2.0
composer require storj/uplink:1.3.0
```

Solves https://github.com/storj-thirdparty/uplink-php/issues/35