### PR TITLE
Release 1.4.0

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -180,6 +180,42 @@
                 "require-dev": {
                     "phpunit/phpunit": "^9.2"
                 }
+            },
+            "1.4.0": {
+                "name": "storj/uplink",
+                "version": "1.4.0",
+                "dist": {
+                    "url": "https://link.storjshare.io/raw/jxmgbsqc4k2bbhuv27556pcoh7ra/uplink-php-releases/uplink-php-v1.4.0.zip",
+                    "type": "zip"
+                },
+                "description": "Storj DCS client",
+                "homepage": "https://github.com/storj-thirdparty/uplink-php",
+                "type": "library",
+                "license": "MIT/Expat",
+                "authors": [
+                    {
+                        "name": "Erik van Velzen",
+                        "email": "erik@evanv.nl"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Storj\\Uplink\\": "src/"
+                    }
+                },
+                "autoload-dev": {
+                    "psr-4": {
+                        "Storj\\Uplink\\Test\\": "test/"
+                    }
+                },
+                "require": {
+                    "php": ">=7.4",
+                    "ext-ffi": "*",
+                    "psr/http-message": "^1.0"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "^9.2"
+                }
             }
         }
     }


### PR DESCRIPTION
Sanity checked using commands:

```
composer init
composer config repositories.storj/uplink composer https://raw.githubusercontent.com/storj-thirdparty/uplink-php/release-1.4/
composer require storj/uplink
> Using version ^1.4 for storj/uplink (...)
php -a
require 'vendor/autoload.php';
$uplink = Storj\Uplink\Uplink::create();
$access = $uplink->parseAccess("...");
```