### PR TITLE
Bump go

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,7 +33,7 @@ pipeline {
         stage('Go build x64') {
             agent {
                 docker {
-                    image 'golang:1.18.3-buster'
+                    image 'golang:1.21.0-bullseye'
                     args "--volume /tmp/gomod:/go/pkg/mod --user root:root"
                 }
             }

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ build/libuplink-aarch64-linux.so: tmp/uplink-c
 		-v $(PWD)/tmp:$(PWD)/tmp \
 		--workdir $(PWD)/tmp/uplink-c \
 		-e CGO_ENABLED=1 \
-		docker.elastic.co/beats-dev/golang-crossbuild:1.18.3-arm \
+		docker.elastic.co/beats-dev/golang-crossbuild:1.20.7-arm \
 		--build-cmd "useradd --create-home --uid $(UID) jenkins && chown -R jenkins /go/pkg/mod && su jenkins -c 'PATH=\$$PATH:/go/bin:/usr/local/go/bin make build'" \
 		-p "linux/arm64"
 	mkdir -p build
@@ -38,7 +38,7 @@ build/libuplink-amd64-windows_nt.dll: tmp/uplink-c
 		-v $(PWD)/tmp:$(PWD)/tmp \
 		--workdir $(PWD)/tmp/uplink-c \
 		-e CGO_ENABLED=1 \
-		docker.elastic.co/beats-dev/golang-crossbuild:1.18.3-main-debian10 \
+		docker.elastic.co/beats-dev/golang-crossbuild:1.20.7-main-debian11 \
 		--build-cmd "useradd --create-home --uid $(UID) jenkins && chown -R jenkins /go/pkg/mod && su jenkins -c 'PATH=\$$PATH:/go/bin:/usr/local/go/bin make build'" \
 		-p "windows/amd64"
 	mkdir -p build

--- a/docker/go-docker/Dockerfile
+++ b/docker/go-docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18.3-buster
+FROM golang:1.21.0-bullseye
 
 RUN apt update
 RUN apt install -y docker.io

--- a/docker/phpunit/Dockerfile
+++ b/docker/phpunit/Dockerfile
@@ -5,8 +5,8 @@ RUN apt-get update \
     && apt-get install -y libffi-dev postgresql git redis-server wget \
     && docker-php-ext-install ffi
 
-RUN wget https://golang.org/dl/go1.17.2.linux-amd64.tar.gz \
-    && tar -xvf go1.17.2.linux-amd64.tar.gz \
+RUN wget https://golang.org/dl/go1.21.0.linux-amd64.tar.gz \
+    && tar -xvf go1.21.0.linux-amd64.tar.gz \
     && mv go /usr/local
 
 ENV GOROOT=/usr/local/go


### PR DESCRIPTION
Build was failing. Keep debian version trailing by one so Uplink-C links with an older glibc version than most users.